### PR TITLE
drivers: npcm4xx: fix compiler warning

### DIFF
--- a/drivers/clock_control/clock_control_npcm4xx.c
+++ b/drivers/clock_control/clock_control_npcm4xx.c
@@ -174,7 +174,6 @@ BUILD_ASSERT(APBSRC_CLK / (APB4DIV_VAL + 1) <= MHZ(100) &&
 static int npcm4xx_clock_control_init(const struct device *dev)
 {
 	struct cdcg_reg *const inst_cdcg = HAL_CDCG_INST(dev);
-	const uint32_t pmc_base = DRV_CONFIG(dev)->base_pmc;
 
 	/*
 	 * Resetting the OSC_CLK (even to the same value) will make the clock
@@ -203,19 +202,6 @@ static int npcm4xx_clock_control_init(const struct device *dev)
 	inst_cdcg->HFCBCD = (APB1DIV_VAL | (APB2DIV_VAL << 4));
 	inst_cdcg->HFCBCD1  = (FIUDIV_VAL << 4);
 	inst_cdcg->HFCBCD2 = APB3DIV_VAL;
-#if 0
-	/*
-	 * Power-down (turn off clock) the modules initially for better
-	 * power consumption.
-	 */
-	NPCM4XX_PWDWN_CTL(pmc_base, NPCM4XX_PWDWN_CTL1) = 0xF9; /* No SDP_PD/FIU_PD */
-	NPCM4XX_PWDWN_CTL(pmc_base, NPCM4XX_PWDWN_CTL2) = 0xFF;
-	NPCM4XX_PWDWN_CTL(pmc_base, NPCM4XX_PWDWN_CTL3) = 0x1F; /* No GDMA_PD */
-	NPCM4XX_PWDWN_CTL(pmc_base, NPCM4XX_PWDWN_CTL4) = 0xFF;
-	NPCM4XX_PWDWN_CTL(pmc_base, NPCM4XX_PWDWN_CTL5) = 0xFA;
-	NPCM4XX_PWDWN_CTL(pmc_base, NPCM4XX_PWDWN_CTL6) = 0xFF;
-	NPCM4XX_PWDWN_CTL(pmc_base, NPCM4XX_PWDWN_CTL7) = 0xE7;
-#endif
 
 	return 0;
 }

--- a/drivers/gpio/gpio_npcm4xx.c
+++ b/drivers/gpio/gpio_npcm4xx.c
@@ -340,9 +340,6 @@ int gpio_npcm4xx_init(const struct device *dev)
 
 	data->pinmux = DEVICE_DT_GET(DT_NODELABEL(pinmux));
 
-	printk("dev offset = %d, base = 0x%x\n", DRV_CONFIG(dev)->pin_offset, DRV_CONFIG(dev)->base);
-	printk("dev wui size = %d port = 0x%x\n", DRV_CONFIG(dev)->wui_size, DRV_CONFIG(dev)->port);
-
 	return 0;
 }
 


### PR DESCRIPTION
Remove useless debug messages and code.