### PR TITLE
support openbic environment

### DIFF
--- a/dts/arm/nuvoton/npcm4xx.dtsi
+++ b/dts/arm/nuvoton/npcm4xx.dtsi
@@ -466,5 +466,5 @@
 };
 
 &nvic {
-	arm,num-irq-priority-bits = <4>;
+	arm,num-irq-priority-bits = <3>;
 };

--- a/soc/arm/npcm4xx/CMakeLists.txt
+++ b/soc/arm/npcm4xx/CMakeLists.txt
@@ -13,6 +13,7 @@ set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
     COMMAND cp ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.bin ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/ImageGenerator/Input
     COMMAND cp ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/ImageGenerator/Xml/_NTC_config.xml ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/ImageGenerator/Xml/_NTC_config_t.xml
     COMMAND sed -i 's/@inputfile/${CONFIG_KERNEL_BIN_NAME}/g' ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/ImageGenerator/Xml/_NTC_config_t.xml
+    COMMAND sed -i 's|@zephyrbase|${ZEPHYR_BASE}|g' ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/ImageGenerator/Xml/_NTC_config_t.xml
     COMMAND ${PYTHON_EXECUTABLE} ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/ImageGenerator/ImageGenerator.py /g ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/ImageGenerator/Xml/_NTC_config_t.xml
     COMMAND cp ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/ImageGenerator/Output/*.bin ${PROJECT_BINARY_DIR}
     COMMAND rm -rf ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/ImageGenerator/Xml/_NTC_config_t.xml

--- a/soc/arm/npcm4xx/common/ImageGenerator/Xml/_NTC_config.xml
+++ b/soc/arm/npcm4xx/common/ImageGenerator/Xml/_NTC_config.xml
@@ -2,7 +2,7 @@
 
 <Description>
 	<Config>
-		<ToolPath>../../soc/arm/npcm4xx/common/ImageGenerator</ToolPath>
+		<ToolPath>@zephyrbase/soc/arm/npcm4xx/common/ImageGenerator</ToolPath>
 	</Config>
 
 	<FileName>


### PR DESCRIPTION
soc: npcm4xx: support sign out-of-tree image
-> support sign image in openbic environment.

dts: npcm4xx: update nvic irq priority bits
-> update nvic irq priority bits to avoid system enter to unpredictable behavior.