### PR TITLE
drivers: wdt: extend the watchdog timeout value.

### DIFF
--- a/drivers/watchdog/Kconfig.npcm4xx
+++ b/drivers/watchdog/Kconfig.npcm4xx
@@ -15,8 +15,10 @@ config WDT_NPCM4XX_DELAY_CYCLES
 	int "Number of delay cycles before generating watchdog event/signal"
 	depends on WDT_NPCM4XX
 	range 1 255
-	default 10
+	default 5
 	help
-	  This option defines the window in which a watchdog event must be
-	  handled, in units of 31ms. After this time window, the watchdog reset
-	  triggers immediately.
+	  This option defines the window in which a watchdog event must be handled.
+	  If the watchdog timeout value is under 1 second, the WDT_NPCM4XX_DELAY_CYCLES unit is 31 ms.
+	  If the watchdog timeout value is under 1 minute, the WDT_NPCM4XX_DELAY_CYCLES unit is 250 ms.
+	  Otherwise, the WDT_NPCM4XX_DELAY_CYCLES unit is 8 second.
+	  After this time window, the watchdog reset triggers immediately.

--- a/soc/arm/npcm4xx/common/reg/reg_def.h
+++ b/soc/arm/npcm4xx/common/reg/reg_def.h
@@ -452,10 +452,10 @@ struct adc_reg {
  */
 struct twd_reg {
 	/* [0x00] Timer and Watchdog Configuration */
-	volatile uint8_t CFG;
+	volatile uint8_t TWCFG;
 	volatile uint8_t reserved1[1];
 	/* [0x02] Timer and Watchdog Clock Prescaler */
-	volatile uint8_t CP;
+	volatile uint8_t TWCP;
 	volatile uint8_t reserved2[1];
 	/* [0x04] TWD Timer 0 Counter Preset */
 	volatile uint16_t TWDT0;
@@ -469,22 +469,22 @@ struct twd_reg {
 	volatile uint8_t WDSDM;
 	volatile uint8_t reserved5[1];
 	/* [0x0C] TWD Timer 0 Counter */
-	volatile uint16_t MT0;
+	volatile uint16_t TWMT0;
 	/* [0x0E] Watchdog Counter */
-	volatile uint8_t MWD;
+	volatile uint8_t TWMWD;
 	volatile uint8_t reserved6[1];
 	/* [0x10] Watchdog Clock Prescaler */
 	volatile uint8_t WDCP;
 };
 
 /* TWD register fields */
-#define TWD_CFG_LTWD_CFG                (0)
-#define TWD_CFG_LTWCP                   (1)
-#define TWD_CFG_LTWDT0                  (2)
-#define TWD_CFG_LWDCNT                  (3)
-#define TWD_CFG_WDCT0I                  (4)
-#define TWD_CFG_WDSDME                  (5)
-#define TWD_CP_MDIV                     (0)
+#define TWD_TWCFG_LTWD_CFG              (0)
+#define TWD_TWCFG_LTWCP                 (1)
+#define TWD_TWCFG_LTWDT0                (2)
+#define TWD_TWCFG_LWDCNT                (3)
+#define TWD_TWCFG_WDCT0I                (4)
+#define TWD_TWCFG_WDSDME                (5)
+#define TWD_TWCP_MDIV                   (0)
 #define TWD_T0CSR_RST                   (0)
 #define TWD_T0CSR_TC                    (1)
 #define TWD_T0CSR_WDLTD                 (3)


### PR DESCRIPTION
1. modify register name define.
2. support the watchdog timeout value up to 250000 seconds.