### PR TITLE
driver: ITIM: npcm4xx: fixed compiler warning and rename ITIM register

### DIFF
--- a/soc/arm/npcm4xx/common/reg/reg_def.h
+++ b/soc/arm/npcm4xx/common/reg/reg_def.h
@@ -1442,11 +1442,11 @@ struct itim32_reg {
 };
 
 /* ITIM32 register fields */
-#define ITIM32_CTS_ITEN                         (7)
-#define ITIM32_CTS_CKSEL                        (4)
-#define ITIM32_CTS_TO_WUE                       (3)
-#define ITIM32_CTS_TO_IE                        (2)
-#define ITIM32_CTS_TO_STS                       (0)
+#define NPCM4XX_CTS_ITEN                         (7)
+#define NPCM4XX_CTS_CKSEL                        (4)
+#define NPCM4XX_CTS_TO_WUE                       (3)
+#define NPCM4XX_CTS_TO_IE                        (2)
+#define NPCM4XX_CTS_TO_STS                       (0)
 
 /*
  * Tachometer (TACH) Sensor device registers


### PR DESCRIPTION
1. Fixed compiler warning of counter_npcm4xx.c
2. Renamed ITIM register fields form ITIM_XXX to NPCM4XX_XXX.