### PR TITLE
update flash driver setting

### DIFF
--- a/boards/arm/npcm400f_evb/npcm400f_evb.dts
+++ b/boards/arm/npcm400f_evb/npcm400f_evb.dts
@@ -56,9 +56,6 @@
 };
 
 &spi_fiu0_cs1 {
-	/* 256 => 32M */
-	size = <DT_SIZE_M(256)>;
-	write-block-size = <4096>;
 	status = "okay";
 };
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -13,7 +13,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <drivers/flash.h>
+#include <drivers/spi_nor.h>
 #include <soc.h>
+
+#include <kernel.h>
 
 #define BUF_ARRAY_CNT 16
 #define TEST_ARR_SIZE 0x1000
@@ -24,7 +27,15 @@
 #define FLASH_DEV_NAME ""
 #endif
 
-static uint8_t __aligned(4) test_arr[TEST_ARR_SIZE];
+#if defined(CONFIG_SPI_NPCM4XX_FIU)
+static uint8_t test_arr[TEST_ARR_SIZE];
+static uint8_t read_back_arr[TEST_ARR_SIZE];
+static uint8_t op_arr[TEST_ARR_SIZE];
+#else
+static uint8_t test_arr[TEST_ARR_SIZE] NON_CACHED_BSS_ALIGN16;
+static uint8_t read_back_arr[TEST_ARR_SIZE] NON_CACHED_BSS_ALIGN16;
+static uint8_t op_arr[TEST_ARR_SIZE] NON_CACHED_BSS_ALIGN16;
+#endif
 
 static int parse_helper(const struct shell *shell, size_t *argc,
 		char **argv[], const struct device * *flash_dev,
@@ -228,6 +239,218 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 	return result;
 }
 
+static int do_erase_write_verify(const struct device *flash_device,
+			uint32_t op_addr, uint8_t *write_buf, uint8_t *read_back_buf,
+			uint32_t erase_sz)
+{
+	uint32_t ret = 0;
+	uint32_t i;
+
+	ret = flash_erase(flash_device, op_addr, erase_sz);
+	if (ret != 0) {
+		printk("[%s][%d] erase failed at %d.\n",
+			__func__, __LINE__, op_addr);
+		goto end;
+	}
+
+	ret = flash_write(flash_device, op_addr, write_buf, erase_sz);
+	if (ret != 0) {
+		printk("[%s][%d] write failed at %d.\n",
+			__func__, __LINE__, op_addr);
+		goto end;
+	}
+
+	flash_read(flash_device, op_addr, read_back_buf, erase_sz);
+	if (ret != 0) {
+		printk("[%s][%d] write failed at %d.\n",
+			__func__, __LINE__, op_addr);
+		goto end;
+	}
+
+	if (memcmp(write_buf, read_back_buf, erase_sz) != 0) {
+		ret = -EINVAL;
+		printk("ERROR: %s %d fail to write flash at 0x%x\n",
+				__func__, __LINE__, op_addr);
+		printk("to be written:\n");
+		for (i = 0; i < 256; i++) {
+			printk("%x ", write_buf[i]);
+			if (i % 16 == 15)
+				printk("\n");
+		}
+
+		printk("readback:\n");
+		for (i = 0; i < 256; i++) {
+			printk("%x ", read_back_buf[i]);
+			if (i % 16 == 15)
+				printk("\n");
+		}
+
+		goto end;
+	}
+
+end:
+	return ret;
+}
+
+static int do_update(const struct device *flash_device,
+				off_t offset, uint8_t *buf, size_t len)
+{
+	int ret = 0;
+	uint32_t flash_sz = flash_get_flash_size(flash_device);
+	uint32_t sector_sz = flash_get_write_block_size(flash_device);
+	uint32_t flash_offset = (uint32_t)offset;
+	uint32_t remain, op_addr = 0, end_sector_addr;
+	uint8_t *update_ptr = buf, *op_buf = NULL, *read_back_buf = NULL;
+	bool update_it = false;
+
+	printk("Writing %d bytes to %s (offset: 0x%08x)...\n",
+			len, flash_device->name, offset);
+
+	if (flash_sz < flash_offset + len) {
+		printk("ERROR: update boundary exceeds flash size. (%d, %d, %d)\n",
+			flash_sz, flash_offset, len);
+		ret = -EINVAL;
+		goto end;
+	}
+
+	op_buf = (uint8_t *)op_arr;
+	read_back_buf = (uint8_t *)read_back_arr;
+
+	/* initial op_addr */
+	op_addr = (flash_offset / sector_sz) * sector_sz;
+
+	/* handle the start part which is not multiple of sector size */
+	if (flash_offset % sector_sz != 0) {
+		ret = flash_read(flash_device, op_addr, op_buf, sector_sz);
+		if (ret != 0)
+			goto end;
+
+		remain = MIN(sector_sz - (flash_offset % sector_sz), len);
+		memcpy((uint8_t *)op_buf + (flash_offset % sector_sz), update_ptr, remain);
+		ret = do_erase_write_verify(flash_device, op_addr, op_buf,
+								read_back_buf, sector_sz);
+		if (ret != 0)
+			goto end;
+
+		op_addr += sector_sz;
+		update_ptr += remain;
+	}
+
+	end_sector_addr = (flash_offset + len) / sector_sz * sector_sz;
+	/* handle body */
+	for (; op_addr < end_sector_addr;) {
+		ret = flash_read(flash_device, op_addr, op_buf, sector_sz);
+		if (ret != 0)
+			goto end;
+
+		if (memcmp(op_buf, update_ptr, sector_sz) != 0)
+			update_it = true;
+
+		if (update_it) {
+			ret = do_erase_write_verify(flash_device, op_addr, update_ptr,
+								read_back_buf, sector_sz);
+			if (ret != 0)
+				goto end;
+		}
+
+		op_addr += sector_sz;
+		update_ptr += sector_sz;
+	}
+
+	/* handle remain part */
+	if (end_sector_addr < flash_offset + len) {
+
+		ret = flash_read(flash_device, op_addr, op_buf, sector_sz);
+		if (ret != 0)
+			goto end;
+
+		remain = flash_offset + len - end_sector_addr;
+		memcpy((uint8_t *)op_buf, update_ptr, remain);
+
+		ret = do_erase_write_verify(flash_device, op_addr, op_buf,
+								read_back_buf, sector_sz);
+		if (ret != 0)
+			goto end;
+
+		op_addr += remain;
+	}
+
+end:
+	printk("Update %s.\n", ret ? "FAILED" : "done");
+
+	return ret;
+}
+
+#define UPDATE_TEST_PATTERN_SIZE (TEST_ARR_SIZE - 4)
+
+static int cmd_update_test(const struct shell *shell, size_t argc, char *argv[])
+{
+	int ret = 0;
+	const struct device *flash_dev;
+	uint32_t addr;
+	int cnt;
+	static bool test_repeat = true;
+	uint32_t i;
+
+	ret = parse_helper(shell, &argc, &argv, &flash_dev, &addr);
+	if (ret) {
+		return ret;
+	}
+
+	if (argc > 2) {
+		cnt = strtoul(argv[2], NULL, 16);
+	} else {
+		cnt = 1;
+	}
+
+	while (cnt > 0) {
+		if (test_repeat) {
+			for (i = 0; i < UPDATE_TEST_PATTERN_SIZE; i++) {
+				test_arr[i] = 'a' + (i % 26);
+			}
+		} else {
+			for (i = 0; i < UPDATE_TEST_PATTERN_SIZE; i++) {
+				test_arr[i] = 'z' - (i % 26);
+			}
+		}
+
+		ret = do_update(flash_dev, addr, test_arr, UPDATE_TEST_PATTERN_SIZE);
+		if (ret != 0) {
+			printk("RW test fail\n");
+			break;
+		}
+
+		printk("RW test pass\n");
+
+		test_repeat ^= true;
+		cnt--;
+	}
+
+	return ret;
+}
+
+static int cmd_address_mode_config(const struct shell *shell, size_t argc, char *argv[])
+{
+	int ret = 0;
+	const struct device *flash_dev;
+	uint32_t addr_mode;
+
+	ret = parse_helper(shell, &argc, &argv, &flash_dev, &addr_mode);
+	if (ret)
+		return ret;
+
+	if (addr_mode == 4) {
+		ret = spi_nor_config_4byte_mode(flash_dev, true);
+	} else if (addr_mode == 3) {
+		ret = spi_nor_config_4byte_mode(flash_dev, false);
+	} else {
+		shell_error(shell, "Wrong addrss mode: %d", addr_mode);
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
 static void device_name_get(size_t idx, struct shell_static_entry *entry);
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
@@ -255,6 +478,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(flash_cmds,
 	SHELL_CMD_ARG(write, &dsub_device_name,
 		"[<device>] <address> <dword> [<dword>...]",
 		cmd_write, 3, BUF_ARRAY_CNT),
+	SHELL_CMD_ARG(update_test, &dsub_device_name,
+		"[<device>] <address> [<count>]",
+		cmd_update_test, 2, 2),
+	SHELL_CMD_ARG(addr_mode, NULL,
+		"[<device>] <address byte mode>",
+		cmd_address_mode_config, 3, 0),
+
 	SHELL_SUBCMD_SET_END
 );
 

--- a/soc/arm/npcm4xx/common/reg/reg_def.h
+++ b/soc/arm/npcm4xx/common/reg/reg_def.h
@@ -93,6 +93,7 @@ struct cdcg_reg {
 	volatile uint8_t  reserved11;
 };
 
+
 /* CDCG register fields */
 #define NPCM4XX_HFCGCTRL_LOAD                    0
 #define NPCM4XX_HFCGCTRL_LOCK                    2
@@ -573,7 +574,7 @@ struct fiu_reg {
 
 /* FIU register fields */
 /* 0x001: BURST CFG */
-#define NPCM4XX_BURST_CFG_R_BURST               FIELD(0, 1)
+#define NPCM4XX_BURST_CFG_R_BURST               FIELD(0, 2)
 #define NPCM4XX_BURST_CFG_SLAVE                 2
 #define NPCM4XX_BURST_CFG_UNLIM_BURST           3
 #define NPCM4XX_BURST_CFG_SPI_WR_EN             7
@@ -582,13 +583,13 @@ struct fiu_reg {
 #define NCPM4XX_RESP_CFG_QUAD_EN                3
 
 /* 0x014: SPI FL CFG */
-#define NPCM4XX_SPI_FL_CFG_RD_MODE              FIELD(6, 7)
+#define NPCM4XX_SPI_FL_CFG_RD_MODE              FIELD(6, 2)
 #define NPCM4XX_SPI_FL_CFG_RD_MODE_NORMAL       0
 #define NPCM4XX_SPI_FL_CFG_RD_MODE_FAST         1
 #define NPCM4XX_SPI_FL_CFG_RD_MODE_FAST_DUAL    3
 
 /* 0x01E: UMA CTS */
-#define NPCM4XX_UMA_CTS_D_SIZE                  FIELD(0, 2)
+#define NPCM4XX_UMA_CTS_D_SIZE                  FIELD(0, 3)
 #define NPCM4XX_UMA_CTS_A_SIZE                  3
 #define NPCM4XX_UMA_CTS_C_SIZE                  4
 #define NPCM4XX_UMA_CTS_RD_WR                   5
@@ -600,7 +601,7 @@ struct fiu_reg {
 #define NPCM4XX_UMA_ECTS_SW_CS1                 1
 #define NPCM4XX_UMA_ECTS_SW_CS2                 2
 #define NPCM4XX_UMA_ECTS_DEV_NUM_BACK           3
-#define NPCM4XX_UMA_ECTS_UMA_ADDR_SIZE          FIELD(4, 6)
+#define NPCM4XX_UMA_ECTS_UMA_ADDR_SIZE          FIELD(4, 3)
 
 /* 0x026: CRC Control Register */
 #define NPCM4XX_CRCCON_CALCEN                   0
@@ -630,7 +631,7 @@ struct fiu_reg {
 #define NPCM4XX_Q_P_EN_QUAD_P_EN                0
 
 /* 0x048: Extended data byte configurartion */
-#define NPCM4XX_EXT_DB_CFG_D_SIZE_DB            FIELD(0, 4)
+#define NPCM4XX_EXT_DB_CFG_D_SIZE_DB            FIELD(0, 5)
 #define NPCM4XX_EXT_DB_CFG_EXT_DB_EN            5
 
 /* 0x049: Direct write configuration */


### PR DESCRIPTION
soc: npcm4xx: fix spi fiu register bank access offset
-> fix fiu bank access offset to avoid overflow access.

drivers: flash: support openbic shell test case
-> sync code from openbic framework

boards: npcm400f_evb: remove dts spi nor setting
-> use sfdp information to configure spi nor layout.
