### PR TITLE
drivers: adc: fix build break when enable shell feature

### DIFF
--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -31,6 +31,8 @@
 #define DT_DRV_COMPAT st_stm32_adc
 #elif DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcx_adc)
 #define DT_DRV_COMPAT nuvoton_npcx_adc
+#elif DT_HAS_COMPAT_STATUS_OKAY(nuvoton_npcm4xx_adc)
+#define DT_DRV_COMPAT nuvoton_npcm4xx_adc
 #elif DT_HAS_COMPAT_STATUS_OKAY(ti_cc32xx_adc)
 #define DT_DRV_COMPAT ti_cc32xx_adc
 #elif DT_HAS_COMPAT_STATUS_OKAY(zephyr_adc_emul)


### PR DESCRIPTION
fix build break when enable shell feature.
add npcm4xx adc device in adc shell.