### PR TITLE
drivers: jtag: npcm4xx: remove set tdo initial value

### DIFF
--- a/drivers/jtag/jtag_npcm4xx.c
+++ b/drivers/jtag/jtag_npcm4xx.c
@@ -558,11 +558,6 @@ static int jtag_npcm4xx_init(const struct device *dev)
 	/* setup tdo */
 	flags = GPIO_INPUT;
 
-	if (config->gpio_tdo.flags & GPIO_ACTIVE_LOW)
-		flags |= GPIO_OUTPUT_INIT_HIGH;
-	else
-		flags |= GPIO_OUTPUT_INIT_LOW;
-
 	gpio_pin_configure(tdo_dev, tdo_pin, flags);
 
 	/* setup tms */


### PR DESCRIPTION
remove set tdo initial value.

tdo set as gpio input, no need set initial value to avoid system assert.