### PR TITLE
drivers: i3c: fix npcm4xx i3c send IBI race condition issue

### DIFF
--- a/drivers/i3c/NPCM4XX/i3c_master.c
+++ b/drivers/i3c/NPCM4XX/i3c_master.c
@@ -24,7 +24,7 @@ extern struct k_work work_rcv_ibi[I3C_PORT_MAX];
 
 __u32 I3C_Master_Callback(__u32 TaskInfo, __u32 ErrDetail)
 {
-	const struct device *dev;
+	const struct device *dev = NULL;
 	struct i3c_npcm4xx_obj *obj;
 	struct i3c_npcm4xx_xfer *xfer;
 	I3C_TASK_INFO_t *pTaskInfo;
@@ -52,6 +52,9 @@ __u32 I3C_Master_Callback(__u32 TaskInfo, __u32 ErrDetail)
 	} else {
 
 	}
+
+	if (dev == NULL)
+		return I3C_ERR_PARAMETER_INVALID;
 
 	obj = DEV_DATA(dev);
 	xfer = obj->curr_xfer;

--- a/drivers/i3c/NPCM4XX/i3c_slave.c
+++ b/drivers/i3c/NPCM4XX/i3c_slave.c
@@ -227,6 +227,12 @@ I3C_ErrCode_Enum I3C_Slave_Finish_Response(I3C_DEVICE_INFO_t *pDevice)
 
 	pDevice->txOffset = pDevice->txLen;
 
+	if (pDevice->pTxBuf != NULL) {
+		hal_I3C_MemFree(pDevice->pTxBuf);
+		pDevice->pTxBuf = NULL;
+		pDevice->txLen = 0;
+	}
+
 	return I3C_ERR_OK;
 }
 

--- a/include/drivers/i3c/NPCM4XX/pub_I3C.h
+++ b/include/drivers/i3c/NPCM4XX/pub_I3C.h
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <string.h>
+#include <kernel.h>
 
 #include <common/reg/reg_def.h>
 #include <common/reg/reg_access.h>
@@ -554,6 +555,9 @@ struct I3C_DEVICE_INFO {
 	volatile __u8 task_count;
 	struct I3C_TRANSFER_TASK *pTaskListHead;
 	ptrI3C_RetFunc callback;
+
+	struct k_mutex lock;
+	struct k_sem ibi_complete;
 };
 
 #define I3C_DEVICE_INFO_t struct I3C_DEVICE_INFO


### PR DESCRIPTION
fix npcm4xx i3c send IBI race condition issue.

1. add semaphore to wait util master read IBI packet done.

2. fix memory leak issue when IBI finish.