### PR TITLE
drivers: usb: MUST use external clock.

### DIFF
--- a/dts/arm/nuvoton/npcm400f.dtsi
+++ b/dts/arm/nuvoton/npcm400f.dtsi
@@ -187,8 +187,8 @@
 			interrupts = <13 3>;
 			num-bidir-endpoints = <13>;
 			usbd-ram-size = <4096>;
-			pinctrl-0 = <&pinctrl_usbd_phy_iclk>;
-			/* pinctrl-0 = <&pinctrl_usbd_phy_xclk>; */
+			/*pinctrl-0 = <&pinctrl_usbd_phy_iclk>;*/
+			pinctrl-0 = <&pinctrl_usbd_phy_xclk>;
 			label = "USBD_0";
 			status = "disabled";
 		};


### PR DESCRIPTION
1. Change the usb device clock input from internal to external.
2. Add a workaround so that usb driver doesn't read the next data if the high-level application has not read the data yet.