### PR TITLE
drivers: watchdog: update ncpm wdt timer to support minimum unit 1ms

### DIFF
--- a/drivers/watchdog/Kconfig.npcm
+++ b/drivers/watchdog/Kconfig.npcm
@@ -16,8 +16,8 @@ config WDT_NPCM_DELAY_CYCLES
 	int "Number of delay cycles before generating watchdog event/signal"
 	depends on WDT_NPCM
 	range 1 255
-	default 20
+	default 10
 	help
 	  This option defines the window in which a watchdog event must be
-	  handled, in units of 62ms. After this time window, the watchdog reset
+	  handled, in units of 31ms. After this time window, the watchdog reset
 	  triggers immediately.


### PR DESCRIPTION
update ncpm wdt timer to support minimum unit 1ms.

for timer interrupt : 0.975ms per-tick.
for wdt event       : 31ms per-tick.

support 1-8000ms timeout value.

test watchdog shell ok.
test t0out miwu interrupt ok.