### PR TITLE
drivers: i2c: clear BB (bus bus) bit correction

### DIFF
--- a/drivers/i2c/i2c_npcm4xx.c
+++ b/drivers/i2c/i2c_npcm4xx.c
@@ -925,7 +925,7 @@ static int i2c_npcm4xx_transfer(const struct device *dev, struct i2c_msg *msgs,
 	}
 
 	if (bus_busy) {
-		inst->SMBnCST &= ~BIT(NPCM4XX_SMBnCST_BB);
+		inst->SMBnCST |= BIT(NPCM4XX_SMBnCST_BB);
 		i2c_npcm4xx_mutex_unlock(dev);
 		return -EAGAIN;
 	}


### PR DESCRIPTION
The BB bit in SMBnCST register is write 1 clear (W1C).

Use "|=" instead.