### PR TITLE
dts: arm: nuvoton: npcm4: add PWM device tree configuration

### DIFF
--- a/boards/nuvoton/npcm400_evb/npcm400_evb.dts
+++ b/boards/nuvoton/npcm400_evb/npcm400_evb.dts
@@ -37,6 +37,66 @@
 	pinctrl-names = "default";
 };
 
+&pwm0 {
+	status = "okay";
+	pinctrl-0 = <&pwm0_sl_gp82 &pwm0_i3c5_disable>;
+	pinctrl-names = "default";
+};
+
+&pwm1 {
+	status = "okay";
+	pinctrl-0 = <&pwm1_sl_gp04 &pwm1_rmii_disable &pwm1_sp2i_disable &pwm1_urti_disable>;
+	pinctrl-names = "default";
+};
+
+&pwm2 {
+	status = "okay";
+	pinctrl-0 = <&pwm2_sl_gp36 &pwm2_prt_disable &pwm2_ext32k_disable &pwm2_smb4a_disable>;
+	pinctrl-names = "default";
+};
+
+&pwm3 {
+	status = "okay";
+	pinctrl-0 = <&pwm3_sl_gp64 &pwm3_dpwrok_disable>;
+	pinctrl-names = "default";
+};
+
+&pwm4 {
+	status = "okay";
+	pinctrl-0 = <&pwm4_sl_gpa0>;
+	pinctrl-names = "default";
+};
+
+&pwm5 {
+	status = "okay";
+	pinctrl-0 = <&pwm5_sl_gpa3>;
+	pinctrl-names = "default";
+};
+
+&pwm6 {
+	status = "okay";
+	pinctrl-0 = <&pwm6_sl_gpa5>;
+	pinctrl-names = "default";
+};
+
+&pwm7 {
+	status = "okay";
+	pinctrl-0 = <&pwm7_sl_gp00 &pwm7_rmii_disable &pwm7_cts2_disable>;
+	pinctrl-names = "default";
+};
+
+&pwm8 {
+	status = "okay";
+	pinctrl-0 = <&pwm8_sl_gp02 &pwm8_rmii_disable &pwm8_rts2_disable>;
+	pinctrl-names = "default";
+};
+
+&pwm9 {
+	status = "okay";
+	pinctrl-0 = <&pwm9_sl_gp06 &pwm9_rmii_disable &pwm9_sp2ctl_disable>;
+	pinctrl-names = "default";
+};
+
 &qspi_spim {
 	int_flash: w25q16@80000 {
 		compatible = "nuvoton,npcx-spim-nor";

--- a/dts/arm/nuvoton/npcm/npcm-alts-map.dtsi
+++ b/dts/arm/nuvoton/npcm/npcm-alts-map.dtsi
@@ -140,6 +140,9 @@
 		alt6_prt_sl: alt62 {
 			alts = <&scfg 0x16 0x2 0>;
 		};
+		alt6_prt_dis: alt62-inv {
+			alts = <&scfg 0x16 0x2 1>;
+		};
 		alt6_port80_sl: alt63 {
 			alts = <&scfg 0x16 0x3 0>;
 		};
@@ -175,6 +178,9 @@
 		alt7_ext32ksl: alt75 {
 			alts = <&scfg 0x17 0x5 0>;
 		};
+		alt7_ext32k_dis: alt75-inv {
+			alts = <&scfg 0x17 0x5 1>;
+		};
 		alt7_clkout_sl: alt76 {
 			alts = <&scfg 0x17 0x6 0>;
 		};
@@ -200,8 +206,14 @@
 		alt9_rts2_sl: alt90 {
 			alts = <&scfg 0x19 0x0 0>;
 		};
+		alt9_rts2_dis: alt90-inv {
+			alts = <&scfg 0x19 0x0 1>;
+		};
 		alt9_sp2i_sl: alt91 {
 			alts = <&scfg 0x19 0x1 0>;
+		};
+		alt9_sp2i_dis: alt91-inv {
+			alts = <&scfg 0x19 0x1 1>;
 		};
 		alt9_sp2o_sl: alt92 {
 			alts = <&scfg 0x19 0x2 0>;
@@ -209,14 +221,23 @@
 		alt9_sp2ctl_sl: alt93 {
 			alts = <&scfg 0x19 0x3 0>;
 		};
+		alt9_sp2ctl_dis: alt93-inv {
+			alts = <&scfg 0x19 0x3 1>;
+		};
 		alt9_cts2_sl: alt94 {
 			alts = <&scfg 0x19 0x4 0>;
+		};
+		alt9_cts2_dis: alt94-inv {
+			alts = <&scfg 0x19 0x4 1>;
 		};
 		alt9_ri2_sl: alt95 {
 			alts = <&scfg 0x19 0x5 0>;
 		};
 		alt9_dpwrok_sl: alt96 {
 			alts = <&scfg 0x19 0x6 0>;
+		};
+		alt9_dpwrok_dis: alt96-inv {
+			alts = <&scfg 0x19 0x6 1>;
 		};
 		alt9_s0ix_sl: alt97 {
 			alts = <&scfg 0x19 0x7 0>;
@@ -232,11 +253,17 @@
 		alta_smb4a_sl: alta2 {
 			alts = <&scfg 0x1A 0x2 0>;
 		};
+		alta_smb4a_dis: alta2-inv {
+			alts = <&scfg 0x1A 0x2 1>;
+		};
 		alta_smb5a_sl: alta3 {
 			alts = <&scfg 0x1A 0x3 0>;
 		};
 		alta_i3c5_sl: alta4 {
 			alts = <&scfg 0x1A 0x4 0>;
+		};
+		alta_i3c5_dis: alta4-inv {
+			alts = <&scfg 0x1A 0x4 1>;
 		};
 		alta_smb1b_sl: alta5 {
 			alts = <&scfg 0x1A 0x5 0>;
@@ -254,6 +281,9 @@
 		};
 		altb_urti_sl: altb1 {
 			alts = <&scfg 0x1B 0x1 0>;
+		};
+		altb_urti_dis: altb1-inv {
+			alts = <&scfg 0x1B 0x1 1>;
 		};
 		altb_sp1i_sl: altb2 {
 			alts = <&scfg 0x1B 0x2 0>;
@@ -461,6 +491,9 @@
 		/* SCFG DEVALT 4D */
 		alt4d_rmii_en: alt4d0 {
 			alts = <&scfg 0x4d 0x0 0>;
+		};
+		alt4d_rmii_dis: alt4d0-inv {
+			alts = <&scfg 0x4d 0x0 1>;
 		};
 		alt4d_mdio_en: alt4d1 {
 			alts = <&scfg 0x4d 0x1 0>;

--- a/dts/arm/nuvoton/npcm/npcm.dtsi
+++ b/dts/arm/nuvoton/npcm/npcm.dtsi
@@ -128,6 +128,96 @@
 			status = "disabled";
 		};			
 
+		pwm0: pwm@40080000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40080000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL1 5>;
+			pwm-channel = <0>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm1: pwm@40082000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40082000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL1 6>;
+			pwm-channel = <1>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm2: pwm@40084000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40084000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL1 7>;
+			pwm-channel = <2>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm3: pwm@40086000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40086000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 0>;
+			pwm-channel = <3>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm4: pwm@40088000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40088000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 1>;
+			pwm-channel = <4>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm5: pwm@4008a000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x4008a000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 2>;
+			pwm-channel = <5>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm6: pwm@4008c000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x4008c000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 3>;
+			pwm-channel = <6>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm7: pwm@4008e000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x4008e000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 4>;
+			pwm-channel = <7>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm8: pwm@40090000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40090000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 5>;
+			pwm-channel = <8>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
+		pwm9: pwm@40092000 {
+			compatible = "nuvoton,npcx-pwm";
+			reg = <0x40092000 0x2000>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 6>;
+			pwm-channel = <9>;
+			#pwm-cells = <3>;
+			status = "disabled";
+		};
+
 		miwu0: miwu@400bb000 {
 			compatible = "nuvoton,npcx-miwu";
 			reg = <0x400bb000 0x2000>;

--- a/dts/arm/nuvoton/npcm/npcm4/npcm4-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npcm/npcm4/npcm4-pinctrl.dtsi
@@ -232,16 +232,48 @@
 		pinmux = <&alt4_pwm0_sl>;
 	};
 
+	/omit-if-no-ref/ pwm0_i3c5_disable: pwm0-i3c5-dis {
+		pinmux = <&alta_i3c5_dis>;
+	};
+
 	/omit-if-no-ref/ pwm1_sl_gp04: pwm1-sel {
 		pinmux = <&alt4_pwm1_sl>;
+	};
+
+	/omit-if-no-ref/ pwm1_rmii_disable: pwm1-rmii-dis {
+		pinmux = <&alt4d_rmii_dis>;
+	};
+
+	/omit-if-no-ref/ pwm1_sp2i_disable: pwm1-sp2i-dis {
+		pinmux = <&alt9_sp2i_dis>;
+	};
+
+	/omit-if-no-ref/ pwm1_urti_disable: pwm1-urti-dis {
+		pinmux = <&altb_urti_dis>;
 	};
 
 	/omit-if-no-ref/ pwm2_sl_gp36: pwm2-sel {
 		pinmux = <&alt4_pwm2_sl>;
 	};
 
+	/omit-if-no-ref/ pwm2_prt_disable: pwm2-prt-dis {
+		pinmux = <&alt6_prt_dis>;
+	};
+
+	/omit-if-no-ref/ pwm2_ext32k_disable: pwm2-ext32k-dis {
+		pinmux = <&alt7_ext32k_dis>;
+	};
+
+	/omit-if-no-ref/ pwm2_smb4a_disable: pwm2-smb4a-dis {
+		pinmux = <&alta_smb4a_dis>;
+	};
+
 	/omit-if-no-ref/ pwm3_sl_gp64: pwm3-sel {
 		pinmux = <&alt4_pwm3_sl>;
+	};
+
+	/omit-if-no-ref/ pwm3_dpwrok_disable: pwm3-dpwrok-dis {
+		pinmux = <&alt9_dpwrok_dis>;
 	};
 
 	/omit-if-no-ref/ pwm4_sl_gpa0: pwm4-sel {
@@ -260,12 +292,36 @@
 		pinmux = <&alt5_pwm7_sl>;
 	};
 
+	/omit-if-no-ref/ pwm7_rmii_disable: pwm7-rmii-dis {
+		pinmux = <&alt4d_rmii_dis>;
+	};
+
+	/omit-if-no-ref/ pwm7_cts2_disable: pwm7-cts2-dis {
+		pinmux = <&alt9_cts2_dis>;
+	};
+
 	/omit-if-no-ref/ pwm8_sl_gp02: pwm8-sel {
 		pinmux = <&alt5_pwm8_sl>;
 	};
 
+	/omit-if-no-ref/ pwm8_rmii_disable: pwm8-rmii-dis {
+		pinmux = <&alt4d_rmii_dis>;
+	};
+
+	/omit-if-no-ref/ pwm8_rts2_disable: pwm8-rts2-dis {
+		pinmux = <&alt9_rts2_dis>;
+	};
+
 	/omit-if-no-ref/ pwm9_sl_gp06: pwm9-sel {
 		pinmux = <&alt5_pwm9_sl>;
+	};
+
+	/omit-if-no-ref/ pwm9_rmii_disable: pwm9-rmii-dis {
+		pinmux = <&alt4d_rmii_dis>;
+	};
+
+	/omit-if-no-ref/ pwm9_sp2ctl_disable: pwm9-sp2ctl-dis {
+		pinmux = <&alt9_sp2ctl_dis>;
 	};
 
 	/omit-if-no-ref/ ta0_sl_gp83: ta0_sel {


### PR DESCRIPTION
Add device tree configuration for PWM support on NPCM4:

- Enable PWM nodes in npcm400_evb board configuration
- Add PWM alternate function mappings in npcm-alts-map.dtsi
- Define PWM controller nodes in npcm.dtsi
- Add PWM pinctrl configurations in npcm4-pinctrl.dtsi

Tested: get all pwm nodes
npcm400:~$ pwm cycles
pwm@40092000  pwm@40090000  pwm@4008e000  pwm@4008c000  pwm@4008a000
pwm@40088000  pwm@40086000  pwm@40084000  pwm@40082000  pwm@40080000

Tested: change pwm5 duty cycle
npcm400:~$ pwm cycles pwm@4008a000 5 1000 1000
npcm400:~$ pwm cycles pwm@4008a000 5 1000 500
npcm400:~$ pwm cycles pwm@4008a000 5 1000 0