### PR TITLE
dts: arm: nuvoton: npcm: fix PWM clock control register mappings

### DIFF
--- a/dts/arm/nuvoton/npcm/npcm.dtsi
+++ b/dts/arm/nuvoton/npcm/npcm.dtsi
@@ -131,7 +131,7 @@
 		pwm0: pwm@40080000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40080000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL1 5>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 0>;
 			pwm-channel = <0>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -140,7 +140,7 @@
 		pwm1: pwm@40082000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40082000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL1 6>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 1>;
 			pwm-channel = <1>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -149,7 +149,7 @@
 		pwm2: pwm@40084000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40084000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL1 7>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 2>;
 			pwm-channel = <2>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -158,7 +158,7 @@
 		pwm3: pwm@40086000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40086000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 0>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 3>;
 			pwm-channel = <3>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -167,7 +167,7 @@
 		pwm4: pwm@40088000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40088000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 1>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 4>;
 			pwm-channel = <4>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -176,7 +176,7 @@
 		pwm5: pwm@4008a000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x4008a000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 2>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 5>;
 			pwm-channel = <5>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -185,7 +185,7 @@
 		pwm6: pwm@4008c000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x4008c000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 3>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 6>;
 			pwm-channel = <6>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -194,7 +194,7 @@
 		pwm7: pwm@4008e000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x4008e000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 4>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 7>;
 			pwm-channel = <7>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -203,7 +203,7 @@
 		pwm8: pwm@40090000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40090000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 5>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL0 0>;
 			pwm-channel = <8>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -212,7 +212,7 @@
 		pwm9: pwm@40092000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40092000 0x2000>;
-			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL2 6>;
+			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL0 1>;
 			pwm-channel = <9>;
 			#pwm-cells = <3>;
 			status = "disabled";


### PR DESCRIPTION
The PWM clock configurations in npcm.dtsi were incorrectly mapped to PWDWN_CTL registers. According to the NPCM400 hardware specification, the PWM modules use the following power-down control mappings:

Hardware Name    Software PWM    PWDWN_CTL Register
-------------    ------------    ------------------
PWM_A (bit 0)    pwm0            PWDWN_CTL2[0]
PWM_B (bit 1)    pwm1            PWDWN_CTL2[1]
PWM_C (bit 2)    pwm2            PWDWN_CTL2[2]
PWM_D (bit 3)    pwm3            PWDWN_CTL2[3]
PWM_E (bit 4)    pwm4            PWDWN_CTL2[4]
PWM_F (bit 5)    pwm5            PWDWN_CTL2[5]
PWM_G (bit 6)    pwm6            PWDWN_CTL2[6]
PWM_H (bit 7)    pwm7            PWDWN_CTL2[7]
PWM_I (bit 0)    pwm8            PWDWN_CTL0[0]
PWM_J (bit 1)    pwm9            PWDWN_CTL0[1]

This fix ensures PWM modules are correctly powered on/off through their designated power-down control register bits.