### PR TITLE
dts: npcm: correct MIWU interrupt mappings for npcm4

### DIFF
--- a/dts/arm/nuvoton/npcm/npcm-miwus-int-map.dtsi
+++ b/dts/arm/nuvoton/npcm/npcm-miwus-int-map.dtsi
@@ -72,25 +72,10 @@
 				irq-prio   = <2>;
 				group-mask = <0x04>;
 			};
-			/* disable group D1 interrupt as eSPI is powered down */
-			/*
 			group_d1: group-d1-map {
 				irq        = <51>;
 				irq-prio   = <2>;
 				group-mask = <0x08>;
-			};
-			*/
-			/*
-			group_e1a: group-e1a-map {
-				irq        = <36>;
-				irq-prio   = <2>;
-				group-mask = <0x10>;
-			};
-			*/
-			group_e1b: group-e1b-map {
-				irq        = <12>;
-				irq-prio   = <2>;
-				group-mask = <0x10>;
 			};
 			group_f1: group-f1-map {
 				irq        = <53>;


### PR DESCRIPTION
Changes:
- Remove non-MIWU interrupts from MIWU1 Group E mapping
  * Remove group_e1a using INT36 (EMAC peripheral interrupt)
  * Remove group_e1b using INT12 (MSWC/T0OUT peripheral interrupt)

- Enable MIWU1 Group D1 interrupt (INT51)
  * Uncomment group_d1 mapping for eSPI/LPC wake-up sources
  * Supports: CDBGPWRUPREQ, LPC_EV_WKUP, Host Access, PLTRST/eSPI_RST
  * Required for eSPI Virtual Wire and LPC interface wake-up events