### PR TITLE
dts: npcm: add SIOX1 and SIOX2 wake-up sources for npcm4

### DIFF
--- a/dts/arm/nuvoton/npcm/npcm-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npcm/npcm-miwus-wui-map.dtsi
@@ -321,6 +321,12 @@
 		wui_t0out: wui1-5-3 {
 			miwus = <&miwu1 4 3>; /* T0OUT */
 		};
+		wui_siox1: wui1-5-4 {
+			miwus = <&miwu1 4 4>; /* SIOX1 Wake-up */
+		};
+		wui_siox2: wui1-5-5 {
+			miwus = <&miwu1 4 5>; /* SIOX2 Wake-up */
+		};
 
 		/* MIWU group F */
 		wui_iob0: wui1-6-0 {


### PR DESCRIPTION
Changes:
- Add wui_siox1 node for SIOX1 Wake-up at MIWU1 Group E Bit 4 (WUI54)
- Add wui_siox2 node for SIOX2 Wake-up at MIWU1 Group E Bit 5 (WUI55)