### PR TITLE
drivers: npcm4xx: fix XIP faults from writes to const device config

### DIFF
--- a/drivers/clock_control/clock_control_npcm4xx.c
+++ b/drivers/clock_control/clock_control_npcm4xx.c
@@ -36,7 +36,7 @@ static inline int npcm4xx_clock_control_on(const struct device *dev,
 					 clock_control_subsys_t sub_system)
 {
 	ARG_UNUSED(dev);
-	struct npcm4xx_clk_cfg *clk_cfg = (struct npcm4xx_clk_cfg *)(sub_system);
+	const struct npcm4xx_clk_cfg *clk_cfg = (const struct npcm4xx_clk_cfg *)(sub_system);
 	const uint32_t pmc_base = DRV_CONFIG(dev)->base_pmc;
 
 	if (clk_cfg->ctrl >= NPCM4XX_PWDWN_CTL_COUNT)
@@ -51,7 +51,7 @@ static inline int npcm4xx_clock_control_off(const struct device *dev,
 					  clock_control_subsys_t sub_system)
 {
 	ARG_UNUSED(dev);
-	struct npcm4xx_clk_cfg *clk_cfg = (struct npcm4xx_clk_cfg *)(sub_system);
+	const struct npcm4xx_clk_cfg *clk_cfg = (const struct npcm4xx_clk_cfg *)(sub_system);
 	const uint32_t pmc_base = DRV_CONFIG(dev)->base_pmc;
 
 	if (clk_cfg->ctrl >= NPCM4XX_PWDWN_CTL_COUNT)
@@ -66,7 +66,7 @@ static int npcm4xx_clock_control_get_subsys_rate(const struct device *dev,
 						 clock_control_subsys_t sub_system, uint32_t *rate)
 {
 	struct cdcg_reg *const inst_cdcg = HAL_CDCG_INST(dev);
-	struct npcm4xx_clk_cfg *clk_cfg = (struct npcm4xx_clk_cfg *)(sub_system);
+	const struct npcm4xx_clk_cfg *clk_cfg = (const struct npcm4xx_clk_cfg *)(sub_system);
 
 	/* Get divider */
 	uint32_t hfcgp = inst_cdcg->HFCGP;

--- a/drivers/gpio/gpio_npcm4xx_sgpio.c
+++ b/drivers/gpio/gpio_npcm4xx_sgpio.c
@@ -48,10 +48,14 @@ struct sgpio_npcm4xx_parent_config {
 	/* clock configuration */
 	struct npcm4xx_clk_cfg clk_cfg;
 	sgpio_irq_config_func_t irq_conf_func;
-	struct k_spinlock lock;
 	uint32_t sgpio_freq;
 	uint8_t nin_sgpio;
 	uint8_t nout_sgpio;
+};
+
+/* Parent driver data (mutable; must not live in the const config) */
+struct sgpio_npcm4xx_parent_data {
+	struct k_spinlock lock;
 	uint8_t in_port;
 	uint8_t out_port;
 };
@@ -84,9 +88,11 @@ static const struct npcm4xx_scfg_config npcm4xx_scfg_cfg = {
 };
 
 /* Driver convenience defines */
-#define DRV_PARENT_CFG(dev) ((struct sgpio_npcm4xx_parent_config *)(dev)->config)
+#define DRV_PARENT_CFG(dev) ((const struct sgpio_npcm4xx_parent_config *)(dev)->config)
 
-#define DRV_CONFIG(dev) ((struct sgpio_npcm4xx_config *)(dev)->config)
+#define DRV_PARENT_DATA(dev) ((struct sgpio_npcm4xx_parent_data *)(dev)->data)
+
+#define DRV_CONFIG(dev) ((const struct sgpio_npcm4xx_config *)(dev)->config)
 
 #define DRV_DATA(dev) ((struct sgpio_npcm4xx_data *)(dev)->data)
 
@@ -118,7 +124,8 @@ static void npcm_sgpio_setup_enable(const struct device *parent, bool enable)
 static int npcm_sgpio_init_port(const struct device *parent)
 {
 	uint8_t in_port, out_port, set_port, reg;
-	struct sgpio_npcm4xx_parent_config *const config = DRV_PARENT_CFG(parent);
+	const struct sgpio_npcm4xx_parent_config *const config = DRV_PARENT_CFG(parent);
+	struct sgpio_npcm4xx_parent_data *const data = DRV_PARENT_DATA(parent);
 	struct sgpio_reg *const inst = HAL_PARENT_INSTANCE(parent);
 
 	in_port = config->nin_sgpio / 8;
@@ -129,8 +136,8 @@ static int npcm_sgpio_init_port(const struct device *parent)
 	if((config->nout_sgpio % 8) > 0 )
 		out_port++;
 
-	config->in_port = in_port;
-	config->out_port = out_port;
+	data->in_port = in_port;
+	data->out_port = out_port;
 
 	set_port = ((out_port & 0xf) << 4) | (in_port & 0xf);
 	inst->IOXCFG2 = set_port;
@@ -452,7 +459,7 @@ int sgpio_npcm4xx_init(const struct device *dev)
 
 int sgpio_npcm4xx_parent_init(const struct device *parent)
 {
-	struct sgpio_npcm4xx_parent_config *const config = DRV_PARENT_CFG(parent);
+	const struct sgpio_npcm4xx_parent_config *const config = DRV_PARENT_CFG(parent);
 	struct sgpio_reg *const inst = HAL_PARENT_INSTANCE(parent);
 	const struct device *const clk_dev =
 					device_get_binding(NPCM4XX_CLK_CTRL_NAME);
@@ -566,7 +573,9 @@ struct device_cont {
 		.child_dev = child_dev_##inst,                                                     \
 		.child_num = ARRAY_SIZE(child_dev_##inst),                                         \
 	};                                                                                         \
-	DEVICE_DT_INST_DEFINE(inst, sgpio_npcm4xx_parent_init, NULL, NULL,                         \
+	static struct sgpio_npcm4xx_parent_data sgpio_npcm4xx_parent_data_##inst;                  \
+	DEVICE_DT_INST_DEFINE(inst, sgpio_npcm4xx_parent_init, NULL,                               \
+			      &sgpio_npcm4xx_parent_data_##inst,                                   \
 			      &sgpio_npcm4xx_parent_cfg_##inst, POST_KERNEL,                       \
 			      CONFIG_GPIO_NPCM4XX_SGPIO_INIT_PRIORITY, NULL);                      \
 	static const struct sgpio_npcm4xx_config sgpio_npcm4xx_cfg_##inst[] = { DT_FOREACH_CHILD(  \

--- a/drivers/i3c/i3c_npcm4.c
+++ b/drivers/i3c/i3c_npcm4.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(i3c_npcm4);
 
 #include <portability/cmsis_os2.h>
 
-#define DEV_CFG(dev)			((struct i3c_npcm4_config *)(dev)->config)
+#define DEV_CFG(dev)			((const struct i3c_npcm4_config *)(dev)->config)
 #define DEV_DATA(dev)			((struct i3c_npcm4_obj *)(dev)->data)
 
 /* NPCM4 PDMA Definitions */
@@ -154,7 +154,7 @@ static inline int readl_poll_timeout(uintptr_t addr, uint32_t mask,
 
 static inline void i3c_npcm4_stop_dma_rx(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	uint32_t val = config->base->DMACTRL & ~GENMASK(1, 0);
 
@@ -163,7 +163,7 @@ static inline void i3c_npcm4_stop_dma_rx(const struct device *dev)
 	obj->state &= ~SLAVE_WAIT_FOR_RX;
 }
 
-static inline void i3c_npcm4_stop_dma_tx(struct i3c_npcm4_config *config)
+static inline void i3c_npcm4_stop_dma_tx(const struct i3c_npcm4_config *config)
 {
 	uint32_t val = config->base->DMACTRL & ~GENMASK(3, 2);
 
@@ -189,7 +189,7 @@ static inline void i3c_npcm4_clear_irq_status(struct i3c_reg *reg, int irq)
 static void i3c_npcm4_register_isr_cb(const struct device *dev, int irq, isr_cb_t cb)
 {
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_reg *reg = config->base;
 
 	if (irq < IRQ_START || irq > IRQ_EVENT)
@@ -208,7 +208,7 @@ static void i3c_npcm4_register_isr_cb(const struct device *dev, int irq, isr_cb_
 
 static int i3c_npcm4_dma_read(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct dsct_reg *desc = (struct dsct_reg *)&config->pdma_base->DSCT[config->dma_rx_channel];
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	uint32_t val = config->base->DMACTRL & ~GENMASK(1, 0);
@@ -243,7 +243,7 @@ static int i3c_npcm4_dma_read(const struct device *dev)
 
 static int i3c_npcm4_dma_write(const struct device *dev, uint8_t *buf, int len)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct dsct_reg *head = (struct dsct_reg *)&config->pdma_base->DSCT[config->dma_tx_channel];
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	struct dsct_reg *desc = &sg_dsct[config->inst_id * 2];
@@ -324,7 +324,7 @@ static int i3c_npcm4_slave_write_fifo(struct i3c_reg *base, uint8_t *buf, int le
 
 static int i3c_npcm4_slave_write(const struct device *dev, uint8_t *buf, int len)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 
 	if (len <= 0 || len > DMA_BUF_SIZE)
@@ -349,7 +349,7 @@ static int i3c_npcm4_slave_write(const struct device *dev, uint8_t *buf, int len
 
 static int i3c_npcm4_slave_generate_ibi(const struct device *dev, uint8_t *payload, int len)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	uint32_t ctrl_val, ibiext_val;
 	int i;
 
@@ -380,7 +380,7 @@ static int i3c_npcm4_slave_generate_ibi(const struct device *dev, uint8_t *paylo
 
 static int i3c_npcm4_isr_rx_done(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	struct dsct_reg *desc = (struct dsct_reg *)&config->pdma_base->DSCT[config->dma_rx_channel];
 	struct i3c_reg *reg = config->base;
@@ -442,7 +442,7 @@ static int i3c_npcm4_isr_rx_done(const struct device *dev)
 
 static int i3c_npcm4_isr_tx_done(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	struct dsct_reg *desc = (struct dsct_reg *)&config->pdma_base->DSCT[config->dma_tx_channel];
 	uint32_t val, tx_done_flag;
@@ -495,7 +495,7 @@ err_quit:
 
 static int i3c_npcm4_isr_check_ibi_done(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	struct i3c_reg *reg = config->base;
 
@@ -518,7 +518,7 @@ static int i3c_npcm4_isr_check_ibi_done(const struct device *dev)
 
 static int i3c_npcm4_isr_receive_stop(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	struct i3c_reg *reg = config->base;
 	uint32_t val;
@@ -544,7 +544,7 @@ static int i3c_npcm4_isr_receive_stop(const struct device *dev)
 
 static int i3c_npcm4_isr_da_changed(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	uint8_t addr = 0;
 
@@ -637,7 +637,7 @@ int i3c_npcm4_master_send_entdaa(struct i3c_dev_desc *i3cdev)
 int i3c_npcm4_slave_register(const struct device *dev, struct i3c_slave_setup *slave_data)
 {
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_reg *reg = config->base;
 	uint32_t status;
 	uint8_t addr;
@@ -667,7 +667,7 @@ int i3c_npcm4_slave_put_read_data(const struct device *dev, struct i3c_slave_pay
 				  struct i3c_ibi_payload *ibi_notify)
 {
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_reg *reg = config->base;
 
 	__ASSERT_NO_MSG(data);
@@ -701,7 +701,7 @@ int i3c_npcm4_slave_put_read_data(const struct device *dev, struct i3c_slave_pay
  */
 int i3c_npcm4_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	uint32_t val;
 
 	val = config->base->DYNADDR;
@@ -721,7 +721,7 @@ int i3c_npcm4_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_
  */
 int i3c_npcm4_slave_get_event_enabling(const struct device *dev, uint32_t *event_en)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	uint32_t status;
 
 	status = config->base->STATUS;
@@ -744,7 +744,7 @@ int i3c_npcm4_slave_get_event_enabling(const struct device *dev, uint32_t *event
  */
 int i3c_npcm4_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *payload)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_reg *reg = config->base;
 	uint8_t addr = 0;
 	uint32_t val;
@@ -780,7 +780,7 @@ static void i3c_npcm4_hj_timeout_handler(struct k_work *work)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct i3c_npcm4_obj *obj =
 		CONTAINER_OF(dwork, struct i3c_npcm4_obj, hj_timeout_work);
-	struct i3c_npcm4_config *config = DEV_CFG(obj->dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(obj->dev);
 	struct i3c_reg *reg = config->base;
 
 	LOG_ERR("HJ request not sent within timeout, cancelling");
@@ -792,7 +792,7 @@ static void i3c_npcm4_hj_timeout_handler(struct k_work *work)
 static int i3c_npcm4_isr_hj_event(const struct device *dev)
 {
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_reg *reg = config->base;
 	uint32_t event = (uint32_t)FIELD_GET(GENMASK(21, 20), reg->STATUS);
 
@@ -813,7 +813,7 @@ static int i3c_npcm4_isr_hj_event(const struct device *dev)
 
 int i3c_npcm4_slave_hj_req(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	struct i3c_reg *reg = config->base;
 	uint8_t addr = 0;
@@ -845,7 +845,7 @@ int i3c_npcm4_slave_hj_req(const struct device *dev)
  */
 int i3c_npcm4_slave_set_static_addr(const struct device *dev, uint8_t static_addr)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_reg *reg = config->base;
 	uint32_t val;
 
@@ -863,7 +863,7 @@ int i3c_npcm4_slave_set_static_addr(const struct device *dev, uint8_t static_add
  */
 int i3c_npcm4_set_pid_extra_info(const struct device *dev, uint16_t extra_info)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_reg *reg = config->base;
 	uint32_t val;
 
@@ -878,7 +878,7 @@ int i3c_npcm4_set_pid_extra_info(const struct device *dev, uint16_t extra_info)
 
 static void i3c_npcm4_slave_isr(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	struct i3c_reg *reg = config->base;
 	uint32_t status = reg->INTMASKED;
@@ -897,7 +897,7 @@ static void i3c_npcm4_slave_isr(const struct device *dev)
 
 static void i3c_npcm4_isr(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 
 	if (config->slave)
 		return i3c_npcm4_slave_isr(dev);
@@ -905,7 +905,7 @@ static void i3c_npcm4_isr(const struct device *dev)
 
 
 static int i3c_npcm4_slave_init(const struct device *dev,
-				struct i3c_npcm4_config *config)
+				const struct i3c_npcm4_config *config)
 {
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	struct i3c_reg *reg = config->base;
@@ -932,7 +932,7 @@ static int i3c_npcm4_slave_init(const struct device *dev,
 
 static int i3c_npcm4_setup_dma(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	uint32_t *PDMA_REQSEL;
 	uint32_t val, shift;
@@ -967,7 +967,7 @@ static int i3c_npcm4_setup_dma(const struct device *dev)
 /* Device initialization */
 static int i3c_npcm4_init(const struct device *dev)
 {
-	struct i3c_npcm4_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4_config *config = DEV_CFG(dev);
 	struct i3c_npcm4_obj *obj = DEV_DATA(dev);
 	const struct device *const clk_dev = device_get_binding(NPCM4XX_CLK_CTRL_NAME);
 	uint32_t apb3_rate;

--- a/drivers/i3c/i3c_npcm4xx.c
+++ b/drivers/i3c/i3c_npcm4xx.c
@@ -190,7 +190,7 @@ void work_send_ibi_fun(struct k_work *item)
 
 void work_entdaa_fun(struct k_work *item)
 {
-	struct i3c_npcm4xx_config *config;
+	const struct i3c_npcm4xx_config *config;
 	struct i3c_npcm4xx_obj *obj;
 	struct i3c_npcm4xx_xfer *xfer;
 	uint8_t i;
@@ -1523,7 +1523,7 @@ I3C_ErrCode_Enum hal_I3C_Stop(I3C_PORT_Enum port)
 static void i3c_npcm4xx_reset(I3C_PORT_Enum port)
 {
 	struct i3c_npcm4xx_obj *obj;
-	struct i3c_npcm4xx_config *config;
+	const struct i3c_npcm4xx_config *config;
 	struct pmc_reg *pmc_base;
 	uint8_t sw_rst;
 
@@ -1850,7 +1850,7 @@ hj_end_ok:
     }
 hj_exit:
     if (obj) {
-        obj->config->hj_req = I3C_HOT_JOIN_STATE_None;
+		obj->hj_req = I3C_HOT_JOIN_STATE_None;
     }
     return ret;
 }
@@ -1948,7 +1948,7 @@ void hal_I3C_MemFree(void *pv)
 
 static uint8_t *pec_append(const struct device *dev, uint8_t *ptr, uint16_t len)
 {
-	struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4xx_config *config = DEV_CFG(dev);
 	I3C_PORT_Enum port;
 	uint8_t *xfer_buf;
 	uint8_t pec_v;
@@ -2011,7 +2011,7 @@ static int i3c_npcm4xx_get_pos(struct i3c_npcm4xx_obj *obj, uint8_t addr)
 
 static void i3c_npcm4xx_wr_tx_fifo(struct i3c_npcm4xx_obj *obj, uint8_t *bytes, int nbytes)
 {
-	struct i3c_npcm4xx_config *config;
+	const struct i3c_npcm4xx_config *config;
 	I3C_PORT_Enum port;
 	I3C_DEVICE_INFO_t *pDevice;
 	I3C_ErrCode_Enum ret;
@@ -2025,7 +2025,7 @@ static void i3c_npcm4xx_wr_tx_fifo(struct i3c_npcm4xx_obj *obj, uint8_t *bytes, 
 
 static void i3c_npcm4xx_start_xfer(struct i3c_npcm4xx_obj *obj, struct i3c_npcm4xx_xfer *xfer)
 {
-	struct i3c_npcm4xx_config *config;
+	const struct i3c_npcm4xx_config *config;
 	I3C_PORT_Enum port;
 	I3C_DEVICE_INFO_t *pDevice;
 	I3C_BUS_INFO_t *pBus;
@@ -2070,7 +2070,7 @@ static void i3c_npcm4xx_start_xfer(struct i3c_npcm4xx_obj *obj, struct i3c_npcm4
 int i3c_npcm4xx_master_attach_device(const struct device *dev, struct i3c_dev_desc *slave)
 {
 	struct i3c_npcm4xx_obj *obj = NULL;
-	struct i3c_npcm4xx_config *config = NULL;
+	const struct i3c_npcm4xx_config *config = NULL;
 	I3C_PORT_Enum port;
 
 	struct i3c_npcm4xx_dev_priv *priv;
@@ -2179,7 +2179,7 @@ int i3c_npcm4xx_master_detach_device(const struct device *dev, struct i3c_dev_de
 {
 	struct i3c_npcm4xx_obj *obj = DEV_DATA(dev);
 	struct i3c_npcm4xx_dev_priv *priv = DESC_PRIV(slave);
-	struct i3c_npcm4xx_config *config = NULL;
+	const struct i3c_npcm4xx_config *config = NULL;
 	I3C_DEVICE_INFO_SHORT_t *pDevInfo;
 	I3C_DEVICE_INFO_t *pDevice = NULL;
 	I3C_BUS_INFO_t *pBus = NULL;
@@ -2341,7 +2341,7 @@ int i3c_npcm4xx_slave_register(const struct device *dev, struct i3c_slave_setup 
 
 int i3c_npcm4xx_slave_set_static_addr(const struct device *dev, uint8_t static_addr)
 {
-        struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4xx_config *config = DEV_CFG(dev);
 	I3C_PORT_Enum port = config->inst_id;
 	I3C_DEVICE_INFO_t *pDevice;
 	uint32_t sconfig;
@@ -2362,7 +2362,7 @@ int i3c_npcm4xx_slave_set_static_addr(const struct device *dev, uint8_t static_a
 int i3c_npcm4xx_slave_put_read_data(const struct device *dev, struct i3c_slave_payload *data,
 	struct i3c_ibi_payload *ibi_notify)
 {
-	struct i3c_npcm4xx_config *config;
+	const struct i3c_npcm4xx_config *config;
 	struct i3c_npcm4xx_obj *obj;
 	I3C_TASK_INFO_t *pTaskInfo;
 	I3C_TRANSFER_TASK_t *pTask;
@@ -2492,7 +2492,8 @@ int i3c_npcm4xx_slave_send_sir(const struct device *dev, struct i3c_ibi_payload 
 
 int i3c_npcm4xx_slave_hj_req(const struct device *dev)
 {
-	struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+	struct i3c_npcm4xx_obj *obj = DEV_DATA(dev);
 	I3C_PORT_Enum port;
 	uint8_t addr;
 
@@ -2505,20 +2506,20 @@ int i3c_npcm4xx_slave_hj_req(const struct device *dev)
 		return -1;
 	}
 
-	if (config->hj_req == I3C_HOT_JOIN_STATE_None) {
-		if (config->rst_reason == NPCM4XX_RESET_REASON_VCC_POWERUP) {
+	if (obj->hj_req == I3C_HOT_JOIN_STATE_None) {
+		if (obj->rst_reason == NPCM4XX_RESET_REASON_VCC_POWERUP) {
 			LOG_WRN("Auto Hot-Join\n");
-			config->hj_req = I3C_HOT_JOIN_STATE_Request;
+			obj->hj_req = I3C_HOT_JOIN_STATE_Request;
 			/* change reset reason to sw-rst, direct hot-join next time */
-			config->rst_reason = NPCM4XX_RESET_REASON_DEBUGGER_RST;
+			obj->rst_reason = NPCM4XX_RESET_REASON_DEBUGGER_RST;
 		} else {
 			LOG_WRN("Direct Hot-Join\n");
-			config->hj_req = I3C_HOT_JOIN_STATE_Queue;
+			obj->hj_req = I3C_HOT_JOIN_STATE_Queue;
 			I3C_Slave_Insert_Task_HotJoin(port);
 			k_work_submit_to_queue(&npcm4xx_i3c_work_q[port], &work_send_ibi[port]);
 		}
 	} else {
-		LOG_WRN("Hot-Join request progress, state = %d\n", config->hj_req);
+		LOG_WRN("Hot-Join request progress, state = %d\n", obj->hj_req);
 	}
 
 	return 0;
@@ -2526,7 +2527,7 @@ int i3c_npcm4xx_slave_hj_req(const struct device *dev)
 
 int i3c_npcm4xx_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr)
 {
-	struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4xx_config *config = DEV_CFG(dev);
 	I3C_PORT_Enum port;
 	uint32_t addr;
 
@@ -2541,7 +2542,7 @@ int i3c_npcm4xx_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynami
 
 int i3c_npcm4xx_slave_get_event_enabling(const struct device *dev, uint32_t *event_en)
 {
-	struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4xx_config *config = DEV_CFG(dev);
 	I3C_PORT_Enum port;
 	uint32_t status;
 
@@ -2561,7 +2562,7 @@ int i3c_npcm4xx_slave_get_event_enabling(const struct device *dev, uint32_t *eve
 
 int i3c_npcm4xx_set_pid_extra_info(const struct device *dev, uint16_t extra_info)
 {
-	struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4xx_config *config = DEV_CFG(dev);
 	I3C_PORT_Enum port = config->inst_id;
 	I3C_DEVICE_INFO_t *pDevice;
 	uint32_t partno;
@@ -2654,7 +2655,7 @@ static uint32_t i3c_npcm4xx_master_send_done(void *pCallbackData, struct I3C_Cal
 int i3c_npcm4xx_master_send_ccc(const struct device *dev, struct i3c_ccc_cmd *ccc)
 {
 	struct i3c_npcm4xx_obj *obj = DEV_DATA(dev);
-	struct i3c_npcm4xx_config *config;
+	const struct i3c_npcm4xx_config *config;
 	struct i3c_npcm4xx_xfer *xfer;
 	int pos = 0, ret = 0;
 	k_spinlock_key_t key;
@@ -3077,7 +3078,7 @@ int i3c_npcm4xx_master_priv_xfer(struct i3c_dev_desc *i3cdev, struct i3c_priv_xf
 
 int i3c_npcm4xx_master_send_entdaa(struct i3c_dev_desc *i3cdev)
 {
-	struct i3c_npcm4xx_config *config;
+	const struct i3c_npcm4xx_config *config;
 	I3C_PORT_Enum port;
 	int ret = 0;
 
@@ -3557,12 +3558,12 @@ void I3C_Slave_ISR(uint8_t I3C_IF)
 	obj = gObj[I3C_IF];
 
 	if (bMATCHSS == false) {
-		if (obj->config->hj_req == I3C_HOT_JOIN_STATE_Request) {
+		if (obj->hj_req == I3C_HOT_JOIN_STATE_Request) {
 			if (intmasked & I3C_INTMASKED_STOP_MASK) {
 				I3C_Slave_Insert_Task_HotJoin(I3C_IF);
 				k_work_submit_to_queue(&npcm4xx_i3c_work_q[I3C_IF],
 						&work_send_ibi[I3C_IF]);
-				obj->config->hj_req = I3C_HOT_JOIN_STATE_Queue;
+				obj->hj_req = I3C_HOT_JOIN_STATE_Queue;
 			}
 		}
 
@@ -3571,10 +3572,10 @@ void I3C_Slave_ISR(uint8_t I3C_IF)
 			bMATCHSS = true;
 		}
 	} else {
-		if (obj->config->hj_req != I3C_HOT_JOIN_STATE_None) {
+		if (obj->hj_req != I3C_HOT_JOIN_STATE_None) {
 			LOG_WRN("MATCHSS set. DA=0x%x\n",
 					I3C_Update_Dynamic_Address((uint32_t) I3C_IF));
-			obj->config->hj_req = I3C_HOT_JOIN_STATE_None;
+			obj->hj_req = I3C_HOT_JOIN_STATE_None;
 		}
 	}
 
@@ -3689,7 +3690,7 @@ void I3C_Slave_ISR(uint8_t I3C_IF)
 				pTaskInfo->result = I3C_ERR_OK;
 				I3C_Slave_End_Request((uint32_t)pTask);
 			}
-			obj->config->hj_req = I3C_HOT_JOIN_STATE_None;
+			obj->hj_req = I3C_HOT_JOIN_STATE_None;
 		}
 
 		intmasked &= ~I3C_INTMASKED_DACHG_MASK;
@@ -4026,7 +4027,7 @@ I3C_ErrCode_Enum GetRegisterIndex(I3C_DEVICE_INFO_t *pDevice, uint16_t rx_cnt, u
 
 static void i3c_npcm4xx_isr(const struct device *dev)
 {
-	struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4xx_config *config = DEV_CFG(dev);
 	I3C_PORT_Enum port = config->inst_id;
 	uint32_t mconfig, sconfig;
 	k_spinlock_key_t key;
@@ -4116,7 +4117,7 @@ static void sir_allowed_worker(struct k_work *work)
 
 static int i3c_npcm4xx_init(const struct device *dev)
 {
-	struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+	const struct i3c_npcm4xx_config *config = DEV_CFG(dev);
 	struct i3c_npcm4xx_obj *obj = DEV_DATA(dev);
 	I3C_PORT_Enum port = config->inst_id;
 	I3C_DEVICE_INFO_t *pDevice;
@@ -4221,9 +4222,9 @@ static int i3c_npcm4xx_init(const struct device *dev)
 	hal_I3C_Config_Device(pDevice);
 
 	/* set hj req as false */
-	config->hj_req = I3C_HOT_JOIN_STATE_None;
+	obj->hj_req = I3C_HOT_JOIN_STATE_None;
 
-	config->rst_reason = npcm4xx_get_reset_reason();
+	obj->rst_reason = npcm4xx_get_reset_reason();
 
 	return 0;
 }

--- a/drivers/i3c/npcm4xx/i3c_drv.h
+++ b/drivers/i3c/npcm4xx/i3c_drv.h
@@ -87,8 +87,6 @@ struct i3c_npcm4xx_config {
 	struct npcm4xx_clk_cfg clk_cfg;
 	bool slave;
 	bool secondary;
-	uint8_t hj_req;
-	enum npcm4xx_reset_reason rst_reason;
 	uint32_t i3c_scl_hz;
 	uint32_t i2c_scl_hz;
 	/* uint16_t manufacture-id; PID[5:4] */
@@ -111,10 +109,12 @@ struct i3c_npcm4xx_obj {
 	volatile uint8_t task_count;
 	struct I3C_TRANSFER_TASK *pTaskListHead;
 
-	struct i3c_npcm4xx_config *config;
+	const struct i3c_npcm4xx_config *config;
 	struct k_spinlock lock;
 	struct k_work work;
 	bool sir_allowed_by_sw;
+	uint8_t hj_req;
+	enum npcm4xx_reset_reason rst_reason;
 	struct {
 		uint32_t ibi_status_correct :1;
 		uint32_t ibi_pec_force_enable :1;
@@ -141,7 +141,7 @@ struct i3c_npcm4xx_obj {
 	uint32_t apb3_rate;
 };
 
-#define DEV_CFG(dev)			((struct i3c_npcm4xx_config *)(dev)->config)
+#define DEV_CFG(dev)			((const struct i3c_npcm4xx_config *)(dev)->config)
 #define DEV_DATA(dev)			((struct i3c_npcm4xx_obj *)(dev)->data)
 #define DESC_PRIV(desc)			((struct i3c_npcm4xx_dev_priv *)(desc)->priv_data)
 

--- a/drivers/ipmi/kcs_npcm4xx.c
+++ b/drivers/ipmi/kcs_npcm4xx.c
@@ -132,7 +132,7 @@ static void kcs_set_state(const struct device *dev, enum kcs_state stat)
 {
 	uint32_t reg;
 	struct kcs_npcm4xx_data *kcs = (struct kcs_npcm4xx_data *)dev->data;
-	struct kcs_npcm4xx_config *cfg = (struct kcs_npcm4xx_config *)dev->config;
+	const struct kcs_npcm4xx_config *cfg = (const struct kcs_npcm4xx_config *)dev->config;
 
 	reg = sys_read8(cfg->base + kcs->str);
 	reg &= ~(KCS_STR_STATE_MASK);
@@ -143,7 +143,7 @@ static void kcs_set_state(const struct device *dev, enum kcs_state stat)
 static void kcs_write_data(const struct device *dev, uint8_t data)
 {
 	struct kcs_npcm4xx_data *kcs = (struct kcs_npcm4xx_data *)dev->data;
-	struct kcs_npcm4xx_config *cfg = (struct kcs_npcm4xx_config *)dev->config;
+	const struct kcs_npcm4xx_config *cfg = (const struct kcs_npcm4xx_config *)dev->config;
 
 	sys_write8(data, cfg->base + kcs->odr);
 }
@@ -151,7 +151,7 @@ static void kcs_write_data(const struct device *dev, uint8_t data)
 static uint8_t kcs_read_data(const struct device *dev)
 {
 	struct kcs_npcm4xx_data *kcs = (struct kcs_npcm4xx_data *)dev->data;
-	struct kcs_npcm4xx_config *cfg = (struct kcs_npcm4xx_config *)dev->config;
+	const struct kcs_npcm4xx_config *cfg = (const struct kcs_npcm4xx_config *)dev->config;
 
 	return sys_read8(cfg->base + kcs->idr);
 }
@@ -288,7 +288,7 @@ void kcs_npcm4xx_isr(const struct device *dev)
 {
 	uint32_t stat;
 	struct kcs_npcm4xx_data *kcs = (struct kcs_npcm4xx_data *)dev->data;
-	struct kcs_npcm4xx_config *cfg = (struct kcs_npcm4xx_config *)dev->config;
+	const struct kcs_npcm4xx_config *cfg = (const struct kcs_npcm4xx_config *)dev->config;
 
 	stat = sys_read8(cfg->base + kcs->str);
 	if (stat & KCS_STR_IBF) {
@@ -371,7 +371,7 @@ static int kcs_npcm4xx_init(const struct device *dev)
 {
 	int rc;
 	struct kcs_npcm4xx_data *kcs = (struct kcs_npcm4xx_data *)dev->data;
-	struct kcs_npcm4xx_config *cfg = (struct kcs_npcm4xx_config *)dev->config;
+	const struct kcs_npcm4xx_config *cfg = (const struct kcs_npcm4xx_config *)dev->config;
 
 	kcs->ibuf_idx = 0;
 	kcs->ibuf_avail = 0;

--- a/drivers/misc/npcm/c2h_npcm.c
+++ b/drivers/misc/npcm/c2h_npcm.c
@@ -37,7 +37,7 @@ struct c2h_npcm_config {
 /* host core-to-host interface local functions */
 static void host_c2h_wait_write_done(const struct device *dev)
 {
-	struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;
+	const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 	uint32_t elapsed_cycles;
 	uint32_t start_cycles = k_cycle_get_32();
@@ -55,7 +55,7 @@ static void host_c2h_wait_write_done(const struct device *dev)
 
 static void host_c2h_wait_read_done(const struct device *dev)
 {
-	struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;
+	const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 	uint32_t elapsed_cycles;
 	uint32_t start_cycles = k_cycle_get_32();
@@ -74,7 +74,7 @@ static void host_c2h_wait_read_done(const struct device *dev)
 void __c2h_config_reg_access(const struct device *dev, SIB_DEVICE_T device,
                 uint16_t offset)
 {
-	struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;
+	const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 
 	/* Enable Core-to-Host access module */
@@ -95,7 +95,7 @@ void __c2h_config_reg_access(const struct device *dev, SIB_DEVICE_T device,
 void __c2h_write_reg(const struct device *dev, SIB_DEVICE_T device,
                 uint16_t offset, uint8_t value)
 {
-	struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;
+	const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 
 	__c2h_config_reg_access(dev, device, offset);
@@ -112,7 +112,7 @@ void __c2h_write_reg(const struct device *dev, SIB_DEVICE_T device,
 uint8_t __c2h_read_reg(const struct device *dev, SIB_DEVICE_T device,
                 uint16_t offset)
 {
-	struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;
+	const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 	uint8_t data_val;
 
@@ -132,7 +132,7 @@ uint8_t __c2h_read_reg(const struct device *dev, SIB_DEVICE_T device,
 
 void c2h_write_io_cfg_reg(const struct device *dev, uint8_t reg_index, uint8_t reg_data)
 {
-	struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;
+	const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 
 	/* Disable interrupts */
@@ -176,7 +176,7 @@ void c2h_write_io_cfg_reg(const struct device *dev, uint8_t reg_index, uint8_t r
 
 uint8_t c2h_read_io_cfg_reg(const struct device *dev, uint8_t reg_index)
 {
-	struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;
+	const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 	uint8_t data_val;
 
@@ -226,7 +226,7 @@ uint8_t c2h_read_io_cfg_reg(const struct device *dev, uint8_t reg_index)
 void rtc_write_offset(const struct device *dev, SIB_RTC_OFFSET_Enum offset,
 		      uint8_t value)
 {
-	struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;
+	const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 
 	/* Disable interrupts */
@@ -248,7 +248,7 @@ void rtc_write_offset(const struct device *dev, SIB_RTC_OFFSET_Enum offset,
 
 uint8_t rtc_read_offset(const struct device *dev, SIB_RTC_OFFSET_Enum offset)
 {
-	struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;
+	const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 	uint8_t value;
 
@@ -280,7 +280,7 @@ uint8_t rtc_read_offset(const struct device *dev, SIB_RTC_OFFSET_Enum offset)
 #define NPCM4XX_C2H_INIT_FUNC_IMPL(inst)				              \
 	static int c2h_init##inst(const struct device *dev)	                      \
 	{								              \
-		struct c2h_npcm_config *cfg = (struct c2h_npcm_config *)dev->config;  \
+		const struct c2h_npcm_config *cfg = (const struct c2h_npcm_config *)dev->config;  \
 		struct c2h_reg *const inst_c2h = cfg->inst_c2h;		              \
 									              \
 		/* Enable Core-to-Host access module */			              \

--- a/drivers/misc/npcm/snoop_npcm.c
+++ b/drivers/misc/npcm/snoop_npcm.c
@@ -77,7 +77,7 @@ int snoop_npcm_register_rx_callback(const struct device *dev, snoop_npcm_rx_call
 static void snoop_npcm_isr(const struct device *dev)
 {
 	uint8_t sts, len;
-	struct snoop_npcm_config *cfg = (struct snoop_npcm_config *)dev->config;
+	const struct snoop_npcm_config *cfg = (const struct snoop_npcm_config *)dev->config;
 	struct snoop_npcm_data *data = (struct snoop_npcm_data *)dev->data;
 
 	sts = sys_read8(cfg->base + DP80STS);
@@ -119,7 +119,7 @@ static void snoop_npcm_isr(const struct device *dev)
 
 static void snoop_npcm_enable(const struct device *dev)
 {
-	struct snoop_npcm_config *cfg = (struct snoop_npcm_config *)dev->config;
+	const struct snoop_npcm_config *cfg = (const struct snoop_npcm_config *)dev->config;
 
 	sys_write8(DP80CTL_RFIFO, cfg->base + DP80CTL);
 	sys_write8(DP80CTL_DP80EN | DP80CTL_RAA, cfg->base + DP80CTL);

--- a/drivers/rtc/rtc_npcm.c
+++ b/drivers/rtc/rtc_npcm.c
@@ -556,7 +556,7 @@ static void rtc_npcm_isr(const struct device *dev, struct npcm4xx_wui *wui)
 
 static int rtc_npcm_init(const struct device *dev)
 {
-	struct rtc_npcm_config *cfg = (struct rtc_npcm_config *)dev->config;
+	const struct rtc_npcm_config *cfg = (const struct rtc_npcm_config *)dev->config;
 	struct c2h_reg *const inst_c2h = cfg->inst_c2h;
 	const struct device *c2h_dev = cfg->c2h_dev;
 	uint8_t val;


### PR DESCRIPTION
## Summary

Under `CONFIG_XIP=y` the NPCM4xx port faults during driver init:
a few drivers write to fields of their `const` device config, which lives in read-only flash under XIP. Without XIP the const config is in SRAM, so the writes silently succeed and the bug stays hidden.

## Commits

- **i3c: npcm4xx** — move `hj_req` / `rst_reason` into the data struct (mutable SRAM). This is the actual fault.
- **gpio: npcm4xx sgpio** — move `in_port` / `out_port` / `lock` into a new parent data struct.
- **drivers: npcm4xx** — const-qualify the config pointers in kcs, c2h, snoop, rtc, clock_control and i3c_npcm4 so future writes fail to compile.

## Verification

Clean XIP build for `npcm400f_evb` (smc-mn) with SGPIO and RTC enabled.